### PR TITLE
Fix local images not being matched on Windows

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,12 @@
     "64": "appearance-64.png"
   },
   "content_scripts": [{
-    "matches": ["*://*/*.png","*://*/*.apng","*://*/*.gif","*://*/*.ico","*://*/*.webp","*://*/*.jxr"],
+    "matches": ["file:///*.png",  "*://*/*.png",
+                "file:///*.apng", "*://*/*.apng",
+                "file:///*.gif",  "*://*/*.gif",
+                "file:///*.ico",  "*://*/*.ico",
+                "file:///*.webp", "*://*/*.webp",
+                "file:///*.jxr",  "*://*/*.jxr"],
     "css": ["transparent_image.css"]
   }]
 }


### PR DESCRIPTION
At least on Windows local files (using file:/// URIs) weren't matched by
existing patterns. Weird, since it worked on Linux few months ago.
Either something changed in Firefox or this is a OS-specific behavior.
Anyway it should work now.